### PR TITLE
Run on 48 kHz, streamline config, better HE-AACv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Liquidsoap + fdkaac + icecast2 on Ubuntu 22.04 LTS. Used for feeding transmitter
 ### Scripts
 `icecast2.sh` Script that installs Icecast 2 with optional SSL via Let's Encrypt/Certbot
 
-`install.sh` Script that installs Liquidsoap 2.1 with fdkaac support. It also enables Liquidsoap as service that automatically starts. The configuration is in `/etc/liquidsoap/radio.liq`
+`install.sh` Script that installs Liquidsoap 2.1 with fdkaac support. It also enables Liquidsoap as service that automatically starts. The configuration is in `/etc/liquidsoap/radio.liq` but there are other more experimental `.liq` files included too.
 
 `stereotool.sh` Script that install StereoTool for audio processing. Work in progress. Not finished or integrated.
 
@@ -15,7 +15,7 @@ Liquidsoap + fdkaac + icecast2 on Ubuntu 22.04 LTS. Used for feeding transmitter
 
 `radio_experimental` Like `radio.liq` but with integrated StereoTool processing on all the streams (very experimental)
 
-`radio_micrompx.liq` Like `radio.liq` but with intergrated MicroMPX for feeding transmitters MPX data (experimental)
+`radio_micrompx.liq` Like `radio.liq` but with intergrated MicroMPX for feeding transmitters MPX data (beta)
 
 # MIT License
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Liquidsoap + fdkaac + icecast2 on Ubuntu 22.04 LTS. Used for feeding transmitters an 'unfallable' source.
 
 ## What's here?
+This repository contains the audio streaming stack for [ZuidWest FM](https://www.zuidwestfm.nl/) in the Netherlands. It uses [Liquidsoap](https://www.liquidsoap.info) as audio router and transcoder, [Icecast](https://www.icecast.org) as server and recently [StereoTool](https://www.thimeo.com/stereo-tool/) for feeding [MicroMPX](https://www.thimeo.com/micrompx/) to transmitters.
 
 ### Scripts
 `icecast2.sh` Script that installs Icecast 2 with optional SSL via Let's Encrypt/Certbot

--- a/icecast2.sh
+++ b/icecast2.sh
@@ -72,4 +72,4 @@ service icecast2 restart
 
 ### SSL IS WIP
 ## This currently doesn't work because let's encrypt _requires_ validation over port 80 while icecast is on port 8000.
-certbot --quiet --text --agree-tos --email $ADMINMAIL --noninteractive --no-eff-email --webroot --webroot-path="/usr/share/icecast2/web" -d "$HOSTNAME" --deploy-hook "cat /etc/letsencrypt/live/$HOSTNAME/fullchain.pem /etc/letsencrypt/live/$HOSTNAME/privkey.pem > /usr/share/icecast2/icecast.pem && service icecast2 reload" certonly --test-cert --dry-run
+# certbot --quiet --text --agree-tos --email $ADMINMAIL --noninteractive --no-eff-email --webroot --webroot-path="/usr/share/icecast2/web" -d "$HOSTNAME" --deploy-hook "cat /etc/letsencrypt/live/$HOSTNAME/fullchain.pem /etc/letsencrypt/live/$HOSTNAME/privkey.pem > /usr/share/icecast2/icecast.pem && service icecast2 reload" certonly --test-cert --dry-run

--- a/radio.liq
+++ b/radio.liq
@@ -18,9 +18,9 @@ output.icecast(%ogg(%flac),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # WEB
-output.icecast(%mp3(bitrate=192),fallible=true,
+output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # MOB
-output.icecast(%fdkaac(channels=2, samplerate=44100, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)

--- a/radio.liq
+++ b/radio.liq
@@ -5,13 +5,13 @@ settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
 # General configuration (do change this)
-icecastserver = icecast.example.org
+icecastserver = "icecast.example.org"
 icecastport = 8000
-icecastpassword = changeme
-fallbackfile = /var/audio/fallback.ogg
+icecastpassword = "changeme"
+fallbackfile = "/var/audio/fallback.ogg"
 
 # Fallback if there is no audio coming from the studio
-noodband = drop_metadata(single('fallbackfile'))
+noodband = drop_metadata(single(fallbackfile))
 
 # Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
@@ -21,12 +21,12 @@ radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=3
 
 # Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)

--- a/radio.liq
+++ b/radio.liq
@@ -21,12 +21,12 @@ radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=3
 
 # Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)

--- a/radio.liq
+++ b/radio.liq
@@ -28,5 +28,5 @@ output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AACv2 stream
-output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
-  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=96, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (96kbit HE-AAC v2)', radio)

--- a/radio.liq
+++ b/radio.liq
@@ -27,6 +27,6 @@ output.icecast(%ogg(%flac),fallible=true,
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
-# Output a low quality HE-AAC v2 stream
-output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
+# Output a low quality HE-AACv2 stream
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)

--- a/radio.liq
+++ b/radio.liq
@@ -1,26 +1,26 @@
-# Configuratie
+# General configuration
 settings.init.daemon.change_user.set(true)
 settings.init.daemon.change_user.group.set("liquidsoap")
 settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
-# Als de studio en fallback er niet zijn, spelen we dit
+# Fallback if there is no audio coming from the studio
 noodband = drop_metadata(single('/var/audio/fallback.ogg'))
 
-# De studio voert hier zijn audio in
+# Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
 
-# Fallback en live combineren
+# Combine fallback and live input
 radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=30.,studio), noodband ])
 
-# STL
+# Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
-# WEB
+# Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
-# MOB
+# Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)

--- a/radio.liq
+++ b/radio.liq
@@ -1,11 +1,17 @@
-# General configuration
+# Daemon configuration (should not be changed)
 settings.init.daemon.change_user.set(true)
 settings.init.daemon.change_user.group.set("liquidsoap")
 settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
+# General configuration (do change this)
+icecastserver = icecast.example.org
+icecastport = 8000
+icecastpassword = changeme
+fallbackfile = /var/audio/fallback.ogg
+
 # Fallback if there is no audio coming from the studio
-noodband = drop_metadata(single('/var/audio/fallback.ogg'))
+noodband = drop_metadata(single('fallbackfile'))
 
 # Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))

--- a/radio.liq
+++ b/radio.liq
@@ -23,4 +23,4 @@ output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
+  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -1,8 +1,14 @@
-# General configuration
+# Daemon configuration (should not be changed)
 settings.init.daemon.change_user.set(true)
 settings.init.daemon.change_user.group.set("liquidsoap")
 settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
+
+# General configuration (do change this)
+icecastserver = icecast.example.org
+icecastport = 8000
+icecastpassword = changeme
+fallbackfile = /var/audio/fallback.ogg
 
 # Fallback if there is no audio coming from the studio
 noodband = drop_metadata(single('/var/audio/fallback.ogg'))

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -30,8 +30,8 @@ output.icecast(%ogg(%flac),fallible=true,
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
-# Output a low quality HE-AAC v2 stream
-output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
+# Output a low quality HE-AACv2 stream
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
   
 # Output both mixes as dummy too, to be sure

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -11,7 +11,7 @@ icecastpassword = changeme
 fallbackfile = /var/audio/fallback.ogg
 
 # Fallback if there is no audio coming from the studio
-noodband = drop_metadata(single('/var/audio/fallback.ogg'))
+noodband = drop_metadata(single('fallbackfile'))
 
 # Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
@@ -24,15 +24,15 @@ radioproc = pipe(process='/bin/stereotool - - -w 8888 -q -k "<xxxxxxxxx>" -s /et
 
 # Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
   
 # Output both mixes as dummy too, to be sure
 output.dummy(fallible=true, radioproc)

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -1,33 +1,33 @@
-# Configuratie
+# General configuration
 settings.init.daemon.change_user.set(true)
 settings.init.daemon.change_user.group.set("liquidsoap")
 settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
-# Als de studio en fallback er niet zijn, spelen we dit
+# Fallback if there is no audio coming from the studio
 noodband = drop_metadata(single('/var/audio/fallback.ogg'))
 
-# De studio voert hier zijn audio in
+# Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
 
-# Fallback en live combineren
+# Combine fallback and live input
 radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=30.,studio), noodband ])
 
-# Kale mix door processing trekken
+# Pipe the final mix trough StereoTool
 radioproc = pipe(process='/bin/stereotool - - -w 8888 -q -k "<xxxxxxxxx>" -s /etc/liquidsoap/st.ini', radio)
 
-# STL
+# Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='icecast.zuidwestfm.nl', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
-# WEB
+# Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='icecast.zuidwestfm.nl', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
-# APP
+# Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='icecast.zuidwestfm.nl', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
+  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
   
-# Altijd alle audio-mixen uitvoeren als dummy
+# Output both mixes as dummy too, to be sure
 output.dummy(fallible=true, radioproc)
 output.dummy(fallible=true, radio)

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -26,7 +26,7 @@ output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
+  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
   
 # Output both mixes as dummy too, to be sure
 output.dummy(fallible=true, radioproc)

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -31,8 +31,8 @@ output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AACv2 stream
-output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
-  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=96, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (96kbit HE-AAC v2)', radio)
   
 # Output both mixes as dummy too, to be sure
 output.dummy(fallible=true, radioproc)

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -5,13 +5,13 @@ settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
 # General configuration (do change this)
-icecastserver = icecast.example.org
+icecastserver = "icecast.example.org"
 icecastport = 8000
-icecastpassword = changeme
-fallbackfile = /var/audio/fallback.ogg
+icecastpassword = "changeme"
+fallbackfile = "/var/audio/fallback.ogg"
 
 # Fallback if there is no audio coming from the studio
-noodband = drop_metadata(single('fallbackfile'))
+noodband = drop_metadata(single(fallbackfile))
 
 # Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
@@ -24,15 +24,15 @@ radioproc = pipe(process='/bin/stereotool - - -w 8888 -q -k "<xxxxxxxxx>" -s /et
 
 # Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
   
 # Output both mixes as dummy too, to be sure
 output.dummy(fallible=true, radioproc)

--- a/radio_experimental.liq
+++ b/radio_experimental.liq
@@ -21,11 +21,11 @@ output.icecast(%ogg(%flac),fallible=true,
   host='icecast.zuidwestfm.nl', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # WEB
-output.icecast(%mp3(bitrate=192),fallible=true,
+output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host='icecast.zuidwestfm.nl', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # APP
-output.icecast(%fdkaac(channels=2, samplerate=44100, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
   host='icecast.zuidwestfm.nl', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
   
 # Altijd alle audio-mixen uitvoeren als dummy

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -1,29 +1,29 @@
-# Configuratie
+# General configuration
 settings.init.daemon.change_user.set(true)
 settings.init.daemon.change_user.group.set("liquidsoap")
 settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
-# Als de studio en fallback er niet zijn, spelen we dit
+# Fallback if there is no audio coming from the studio
 noodband = drop_metadata(single('/var/audio/fallback.ogg'))
 
-# De studio voert hier zijn audio in
+# Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
 
-# Fallback en live combineren
+# Combine fallback and live input
 radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=30.,studio), noodband ])
 
-# STL
+# Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
-# WEB
+# Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
-# MOB
+# Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
 
-# uMPX
+# Feed the audio to StereoTool too, which can generate MicroMPX
 output.external(%wav(channels=2, samplerate=48000), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -1,8 +1,14 @@
-# General configuration
+# Daemon configuration (should not be changed)
 settings.init.daemon.change_user.set(true)
 settings.init.daemon.change_user.group.set("liquidsoap")
 settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
+
+# General configuration (do change this)
+icecastserver = icecast.example.org
+icecastport = 8000
+icecastpassword = changeme
+fallbackfile = /var/audio/fallback.ogg
 
 # Fallback if there is no audio coming from the studio
 noodband = drop_metadata(single('/var/audio/fallback.ogg'))

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -11,7 +11,7 @@ icecastpassword = changeme
 fallbackfile = /var/audio/fallback.ogg
 
 # Fallback if there is no audio coming from the studio
-noodband = drop_metadata(single('/var/audio/fallback.ogg'))
+noodband = drop_metadata(single('fallbackfile'))
 
 # Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
@@ -21,15 +21,15 @@ radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=3
 
 # Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
 output.external(%wav(channels=2, samplerate=48000), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -28,8 +28,8 @@ output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AACv2 stream
-output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
-  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=96, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (96kbit HE-AAC v2)', radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
 output.external(%wav(channels=2, samplerate=48000), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -27,8 +27,8 @@ output.icecast(%ogg(%flac),fallible=true,
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
-# Output a low quality HE-AAC v2 stream
-output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
+# Output a low quality HE-AACv2 stream
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=true, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=true),fallible=true,
   host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -23,7 +23,7 @@ output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
+  host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
 output.external(%wav(channels=2, samplerate=48000), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -5,13 +5,13 @@ settings.init.daemon.change_user.user.set("liquidsoap")
 settings.init.daemon.pidfile.path.set("/dev/null")
 
 # General configuration (do change this)
-icecastserver = icecast.example.org
+icecastserver = "icecast.example.org"
 icecastport = 8000
-icecastpassword = changeme
-fallbackfile = /var/audio/fallback.ogg
+icecastpassword = "changeme"
+fallbackfile = "/var/audio/fallback.ogg"
 
 # Fallback if there is no audio coming from the studio
-noodband = drop_metadata(single('fallbackfile'))
+noodband = drop_metadata(single(fallbackfile))
 
 # Input port for the studio stream
 studio = drop_metadata(input.harbor('studio',port=8080,buffer=8.,max=20.,password='---'))
@@ -21,15 +21,15 @@ radio = fallback (track_sensitive=false, [ strip_blank(max_blank=15.,min_noise=3
 
 # Output a high quality ogg/flac stream
 output.icecast(%ogg(%flac),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # Output a high quality mp3 stream
 output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # Output a low quality HE-AAC v2 stream
 output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
-  host='icecastserver', port=icecastport, password='icecastpassword', mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
+  host=icecastserver, port=icecastport, password=icecastpassword, mount='/zuidwest.aac', name='ZuidWest FM', description='Mobile Stream (64kbit HE-AAC v2)', radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
 output.external(%wav(channels=2, samplerate=48000), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)

--- a/radio_micrompx.liq
+++ b/radio_micrompx.liq
@@ -18,12 +18,12 @@ output.icecast(%ogg(%flac),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.stl', name='ZuidWest FM', description='Studio to Transmitter (ongecomprimeerde audio)', radio)
 
 # WEB
-output.icecast(%mp3(bitrate=192),fallible=true,
+output.icecast(%mp3(bitrate=192,samplerate=48000),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.mp3', name='ZuidWest FM', description='Hoge Kwaliteit Stream (192kbit MP3)', radio)
 
 # MOB
-output.icecast(%fdkaac(channels=2, samplerate=44100, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
+output.icecast(%fdkaac(channels=2, samplerate=48000, bitrate=64, afterburner=false, aot='mpeg4_he_aac_v2', transmux='adts', sbr_mode=false),fallible=true,
   host='localhost', port=80, password='---', mount='/zuidwest.aac', name='ZuidWest FM', description='iPad/Mobile Stream (64kbit AAC)', radio)
 
 # uMPX
-output.external(%wav(channels=2, samplerate=44100), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)
+output.external(%wav(channels=2, samplerate=48000), reopen_on_error=true, "stereotool - /dev/null -w 90 -q -s /etc/stereotool/st.ini", radio)

--- a/stereotool.sh
+++ b/stereotool.sh
@@ -13,7 +13,7 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 if [ "$(cat /etc/debian_version)" != "bookworm/sid" ]; then
-	printf "This script only supports Ubuntu 22.04 LTS. Exiting."
+	printf "This script is only tested on Ubuntu 22.04 LTS. Exiting."
 	exit 1
 fi
 


### PR DESCRIPTION
- Run everything on 48 kHz to ensure compatibility with MicroMPX (192khz audio)
- Streamline configuration with variables 
- Improve quality of HE-AAC v2 stream a lot