### PR TITLE
Update StereoTool

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,10 +73,10 @@ if [ "$USE_ST" == "y" ]; then
     
     if [ "$OS_ARCH" == "amd64" ]; then
         cp "${EXTRACTED_DIR}/libStereoToolX11_intel64.so" /opt/stereotool/st_plugin.so
-        wget https://download.thimeo.com/stereo_tool_cmd_64 -O /opt/stereotool/st_standalone
+        wget https://download.thimeo.com/stereo_tool_cmd_64_1011 -O /opt/stereotool/st_standalone
     elif [ "$OS_ARCH" == "arm64" ]; then
         cp "${EXTRACTED_DIR}/libStereoTool_arm64.so" /opt/stereotool/st_plugin.so
-        wget https://www.stereotool.com/download/stereo_tool_pi2_64 -O /opt/stereotool/st_standalone
+        wget https://download.thimeo.com/stereo_tool_pi2_64_1011 -O /opt/stereotool/st_standalone
     fi
     chmod +x /opt/stereotool/st_standalone
 fi

--- a/install.sh
+++ b/install.sh
@@ -75,25 +75,26 @@ if [ "$USE_ST" == "y" ]; then
     EXTRACTED_DIR=$(find /tmp/* -maxdepth 0 -type d -print0 | xargs -0 ls -td | head -n 1)
     
     if [ "$OS_ARCH" == "amd64" ]; then
-        cp "${EXTRACTED_DIR}/libStereoToolX11_intel64.so" /opt/stereotool/st_plugin.so
+        cp "${EXTRACTED_DIR}/lib/Linux/IntelAMD/64/libStereoToolX11_intel64.so" /opt/stereotool/st_plugin.so
         wget https://download.thimeo.com/stereo_tool_cmd_64_1011 -O /opt/stereotool/st_standalone
     elif [ "$OS_ARCH" == "arm64" ]; then
-        cp "${EXTRACTED_DIR}/libStereoTool_arm64.so" /opt/stereotool/st_plugin.so
+        cp "${EXTRACTED_DIR}/lib/Linux/ARM/64/libStereoTool_arm64.so" /opt/stereotool/st_plugin.so
         wget https://download.thimeo.com/stereo_tool_pi2_64_1011 -O /opt/stereotool/st_standalone
     fi
     chmod +x /opt/stereotool/st_standalone
 fi
 
-# Generate StereoTool config file
+# Generate and patch StereoTool config file
 /opt/stereotool/st_standalone -X /etc/liquidsoap/st.ini
+sed -i 's/^\(Whitelist=\).*$/\1\/0/' /etc/liquidsoap/st.ini
 
 # Fetch fallback sample and configuration files
 wget https://upload.wikimedia.org/wikipedia/commons/6/66/Aaron_Dunn_-_Sonata_No_1_-_Movement_2.ogg -O /var/audio/fallback.ogg
-wget https://raw.githubusercontent.com/oszuidwest/liquidsoap-ubuntu/main/radio.liq -O /etc/liquidsoap/radio.liq
+wget https://raw.githubusercontent.com/oszuidwest/liquidsoap-ubuntu/update-st/radio.liq -O /etc/liquidsoap/radio.liq
 
 # Install and set up service
 rm -f /etc/systemd/system/liquidsoap.service
-wget https://raw.githubusercontent.com/oszuidwest/liquidsoap-ubuntu/main/liquidsoap.service -O /lib/systemd/system/liquidsoap.service
+wget https://raw.githubusercontent.com/oszuidwest/liquidsoap-ubuntu/update-st/liquidsoap.service -O /lib/systemd/system/liquidsoap.service
 systemctl daemon-reload
 if ! systemctl is-enabled liquidsoap.service; then
     systemctl enable liquidsoap.service

--- a/install.sh
+++ b/install.sh
@@ -58,10 +58,13 @@ install_packages silent fdkaac libfdkaac-ocaml libfdkaac-ocaml-dynlink
 wget "$PACKAGE_URL" -O /tmp/liq_2.2.1.deb
 apt -qq -y install /tmp/liq_2.2.1.deb --fix-broken
 
-# Configure directories
-mkdir /etc/liquidsoap
-mkdir /var/audio
-chown -R liquidsoap:liquidsoap /etc/liquidsoap /var/audio
+# Create directories and configure them
+dirs=(/etc/liquidsoap /var/audio)
+for dir in "${dirs[@]}"; do
+    mkdir -p "$dir" && \
+    chown liquidsoap:liquidsoap "$dir" && \
+    chmod g+s "$dir"
+done
 
 # Download and install StereoTool if desired by user
 if [ "$USE_ST" == "y" ]; then
@@ -80,6 +83,9 @@ if [ "$USE_ST" == "y" ]; then
     fi
     chmod +x /opt/stereotool/st_standalone
 fi
+
+# Generate StereoTool config file
+/opt/stereotool/st_standalone -X /etc/liquidsoap/st.ini
 
 # Fetch fallback sample and configuration files
 wget https://upload.wikimedia.org/wikipedia/commons/6/66/Aaron_Dunn_-_Sonata_No_1_-_Movement_2.ogg -O /var/audio/fallback.ogg

--- a/radio.liq
+++ b/radio.liq
@@ -47,7 +47,7 @@ end
 #radioproc = stereotool(library_file="/opt/stereotool/st_plugin.so", license_key="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", preset="/etc/liquidsoap/st.ini", radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
-#output.external(%wav, "/opt/stereotool/st_standalone - /dev/null -w 9000 -r 48000 -q -s /etc/liquidsoap/st.ini -k '<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>'", radio)
+#output.external(%wav, "/opt/stereotool/st_standalone - /dev/null -w 9000 -r 48000 -q", radio)
 
 # Output a high bitrate mp3 stream
 output_icecast_stream(format=%mp3(bitrate=192, samplerate=48000), description="Hoge Kwaliteit Stream (192kbit MP3)", mount="/zuidwest.mp3", source=radio)

--- a/radio.liq
+++ b/radio.liq
@@ -47,7 +47,7 @@ end
 #radioproc = stereotool(library_file="/opt/stereotool/st_plugin.so", license_key="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", preset="/etc/liquidsoap/st.ini", radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
-#output.external(%wav, "/opt/stereotool/st_standalone - /dev/null -w 9000 -r 48000 -q", radio)
+#output.external(%wav, "/opt/stereotool/st_standalone - /dev/null -w 9000 -r 48000 -q -s /etc/liquidsoap/st.ini", radio)
 
 # Output a high bitrate mp3 stream
 output_icecast_stream(format=%mp3(bitrate=192, samplerate=48000), description="Hoge Kwaliteit Stream (192kbit MP3)", mount="/zuidwest.mp3", source=radio)

--- a/radio.liq
+++ b/radio.liq
@@ -47,7 +47,7 @@ end
 #radioproc = stereotool(library_file="/opt/stereotool/st_plugin.so", license_key="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", preset="/etc/liquidsoap/st.ini", radio)
 
 # Feed the audio to StereoTool too, which can generate MicroMPX
-#output.external(%wav, "/opt/stereotool/st_standalone - /dev/null -w 9000 -q -s /etc/liquidsoap/st.ini -k '<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>'", radio)
+#output.external(%wav, "/opt/stereotool/st_standalone - /dev/null -w 9000 -r 48000 -q -s /etc/liquidsoap/st.ini -k '<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>'", radio)
 
 # Output a high bitrate mp3 stream
 output_icecast_stream(format=%mp3(bitrate=192, samplerate=48000), description="Hoge Kwaliteit Stream (192kbit MP3)", mount="/zuidwest.mp3", source=radio)


### PR DESCRIPTION
- Update to StereoTool 10.11
- Always run StereoTool on 48khz sample rate (for MicroMPX on ARM)
- Enable StereoTool web interface by default on port 9000 without a whitelist (patch config file)